### PR TITLE
Expand watertank module documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,15 @@
-initial commit
+# Documentatie Overzicht
+
+Deze map bevat ontwerp- en gebruikersdocumentatie voor het Domobar Control System.
+De belangrijkste bestanden zijn:
+
+- `system-architecture.md` – beschrijft de hardware- en softwarearchitectuur.
+- `domobar-specs.md` – technische specificaties van de Vibiemme Domobar.
+- `calibration-guide.md` – stap-voor-stap kalibratie van de watertankmodule.
+- `system-overview.svg` – visuele weergave van de modules in het systeem.
+- `quickstart-flow.svg` – stroomdiagram om snel aan de slag te gaan.
+
+Open de Markdown-bestanden in een editor of viewer naar keuze en bekijk de SVG's
+in een browser. Begin met `system-overview.svg` voor het grote plaatje en lees
+vervolgens `system-architecture.md` voor meer detail. Gebruik de kalibratiegids
+wanneer je de firmware op een nieuwe machine installeert.

--- a/firmware/watertank_module/README.md
+++ b/firmware/watertank_module/README.md
@@ -1,1 +1,28 @@
-initial commit
+# Watertank Module Firmware
+
+Firmware voor de watertankmodule (ESP32) die het waterniveau meet via een DYP-A02YY
+ultrasone sensor en interlock-uitgangen aanstuurt.
+
+## Configuratie
+
+Instellingen staan in `config.json`. Pas waarden zoals `sample_hz`, `low_pct` en
+`allow_pump_at_low` aan voordat je de bestanden naar de MCU kopieert.
+Wordt `config.json` weggelaten, dan gebruikt de firmware de ingebouwde defaults.
+
+## Flashen en uploaden
+
+1. **Flash MicroPython** op de ESP32 (voorbeeld):
+   ```
+   esptool.py --chip esp32 --port /dev/ttyUSB0 erase_flash
+   esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 460800 write_flash -z 0x1000 micropython.bin
+   ```
+
+2. **Kopieer de firmware** naar de module:
+   ```
+   mpremote connect /dev/ttyUSB0 fs cp main.py :
+   mpremote connect /dev/ttyUSB0 fs cp config.json :
+   ```
+   Pas `config.json` eerst aan indien nodig.
+
+3. **Reset** het board; `main.py` start automatisch. Kalibreer daarna via het
+   WebBLE-dashboard (`CAL FULL`/`CAL EMPTY`).

--- a/web-dashboard/watertank_module/README.md
+++ b/web-dashboard/watertank_module/README.md
@@ -1,1 +1,19 @@
-initial commit
+# Watertank Module Dashboard
+
+WebBLE-dashboard voor diagnose en kalibratie van de watertankmodule.
+
+## Doel
+
+- Toont het actuele waterniveau en de status (OK/LOW/BOTTOM/FAULT).
+- Biedt knoppen voor kalibratie en configuratie.
+
+## Lokaal draaien
+
+1. Zorg voor een browser met WebBluetooth (Chrome/Edge).
+2. Start een lokale server:
+   ```
+   cd web-dashboard/watertank_module
+   python3 -m http.server 8000
+   ```
+3. Open `http://localhost:8000/watertank_module_webble.html` en klik op *Connect*.
+   WebBluetooth vereist een veilige context; `localhost` voldoet hiervoor.


### PR DESCRIPTION
## Summary
- Add overall documentation overview in docs/README
- Explain watertank firmware configuration and flashing steps
- Describe WebBLE dashboard purpose and how to run it locally

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa52638c88329a266a7bb16403cd7