### PR TITLE
Add configurable logging to water tank module

### DIFF
--- a/firmware/watertank_module/config.json
+++ b/firmware/watertank_module/config.json
@@ -10,5 +10,6 @@
   "hysteresis_pct": 4,
   "cal_full_mm": 50,
   "cal_empty_mm": 190,
-  "allow_pump_at_low": true
+  "allow_pump_at_low": true,
+  "log_level": "info"
 }


### PR DESCRIPTION
## Summary
- add simple `log` helper with info/warn/err levels
- replace `print` calls with log function
- expose configurable `log_level` in firmware settings

## Testing
- `python -m py_compile firmware/watertank_module/main.py`
- `python -m json.tool firmware/watertank_module/config.json`

------
https://chatgpt.com/codex/tasks/task_e_689aa56f93bc8329808f8270f28b426e